### PR TITLE
Use destination device for link mastership.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ publish notifications for those devices and links for which it is the master.
 For links 'mastership' is determined by the destination device of the link.
 
 ## Configuration
-The Kafka instance to which the applciation binds defaults to `localhost:9092`.
+The Kafka instance to which the application binds defaults to `localhost:9092`.
 This can be configured via the ONOS command line using the `cfg get` and
 `cfg set` commands on the property
 `org.ciena.onos.KafkaNotificationBridge kafka-server` the value when setting

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ format on the configured Kafka message bus.
 ## Clustering
 When operating in a clustered deployment each application instance will only
 publish notifications for those devices and links for which it is the master.
-For links 'mastership' is determined by the source device of the link.
+For links 'mastership' is determined by the destination device of the link.
 
 ## Configuration
 The Kafka instance to which the applciation binds defaults to `localhost:9092`.

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ~ Copyright 2014 Open Networking Laboratory ~ ~ Licensed under the Apache 
-	License, Version 2.0 (the "License"); ~ you may not use this file except 
-	in compliance with the License. ~ You may obtain a copy of the License at 
-	~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless required by applicable 
-	law or agreed to in writing, software ~ distributed under the License is 
-	distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY 
-	KIND, either express or implied. ~ See the License for the specific language 
-	governing permissions and ~ limitations under the License. -->
+<!--
+  ~ Copyright 2015 Open Networking Laboratory
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/src/main/java/org/ciena/onos/KafkaNotificationBridge.java
+++ b/src/main/java/org/ciena/onos/KafkaNotificationBridge.java
@@ -17,7 +17,6 @@ package org.ciena.onos;
 
 import java.util.Dictionary;
 import java.util.Properties;
-import java.util.concurrent.Future;
 
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
@@ -52,7 +51,7 @@ import com.google.common.base.Strings;
 /**
  * ONOS component that bridges device and link notifications to a Kafka message
  * bus.
- * 
+ *
  * @author David K. Bainbridge (dbainbri@ciena.com)
  */
 @Component(immediate = true)
@@ -93,7 +92,7 @@ public class KafkaNotificationBridge {
 	/**
 	 * Marshal a {@link org.onosproject.net.device.DeviceEvent} to a stringified
 	 * JSON object.
-	 * 
+	 *
 	 * @param event
 	 *            the device event to marshal
 	 * @return stringified JSON encoding of the device event
@@ -128,7 +127,7 @@ public class KafkaNotificationBridge {
 	/**
 	 * Marshal a {@link org.onosproject.net.link.LinkEvent} to a stringified
 	 * JSON object.
-	 * 
+	 *
 	 * @param event
 	 *            the link event to marshal
 	 * @return stringified JSON encoding of the link event
@@ -151,7 +150,7 @@ public class KafkaNotificationBridge {
 	/**
 	 * Called when component configuration options are modified and makes the
 	 * appropriate changes to the components implementation.
-	 * 
+	 *
 	 * @param context
 	 *            component context used to retrieve properties
 	 */
@@ -171,7 +170,7 @@ public class KafkaNotificationBridge {
 	 * Creates a KafkaProducer instances based on the configuration parameters
 	 * of the component. This producer is used internally for sending messages
 	 * over the Kafka bus.
-	 * 
+	 *
 	 * @param newKafkaServer
 	 *            the server and port to which the producer should be connected
 	 */
@@ -269,7 +268,7 @@ public class KafkaNotificationBridge {
 				/*
 				 * Only publish events if the destination of the link is mastered by
 				 * the current instance so that we get some load balancing
-				 * across instances in a clustered environement.
+				 * across instances in a clustered environment.
 				 */
 				if (mastershipService.isLocalMaster(event.subject().dst().deviceId())) {
 					if (producer != null) {

--- a/src/main/java/org/ciena/onos/KafkaNotificationBridge.java
+++ b/src/main/java/org/ciena/onos/KafkaNotificationBridge.java
@@ -267,11 +267,11 @@ public class KafkaNotificationBridge {
 			public void event(LinkEvent event) {
 
 				/*
-				 * Only publish events if the source of the link is mastered by
+				 * Only publish events if the destination of the link is mastered by
 				 * the current instance so that we get some load balancing
 				 * across instances in a clustered environement.
 				 */
-				if (mastershipService.isLocalMaster(event.subject().src().deviceId())) {
+				if (mastershipService.isLocalMaster(event.subject().dst().deviceId())) {
 					if (producer != null) {
 						String encoded = marshalEvent(event);
 						log.error("SEND: {}", encoded);


### PR DESCRIPTION
Since links are currently discovered through LLDP, 
destination Device is likely to be the first to detect the link.